### PR TITLE
Fix license field in Cargo.toml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+- Fix `license` field in Cargo.toml to `BSD-3-Clause` to match the LICENSE file (was incorrectly set to `MIT`)
+
 ## v0.3.1
 
 - Relax `serde` version requirement

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "gem_version"
 version = "0.3.1"
 edition = "2021"
-license = "MIT"
+license = "BSD-3-Clause"
 description = "Ruby's Gem::Version comparison logic in Rust"
 keywords = ["Ruby", "version"]
 repository = "https://github.com/schneems/gem_version"


### PR DESCRIPTION
## Summary

- Update `license` in Cargo.toml from "MIT" to "BSD-3-Clause" to match the LICENSE file.