### PR TITLE
Remove Default derive from GemVersion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 - Fix `license` field in Cargo.toml to `BSD-3-Clause` to match the LICENSE file (was incorrectly set to `MIT`)
+- Remove `Default` implementation from `GemVersion`. There is no meaningful default version string, and providing one via `Default` could silently hide bugs.
 
 ## v0.3.1
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@ use std::sync::OnceLock;
 use serde::{Deserialize, Serialize};
 
 /// See module docs for a usage example
-#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(try_from = "String", into = "String")]
 pub struct GemVersion {
     segments: Vec<VersionSegment>,


### PR DESCRIPTION
## Summary

- Remove `Default` derive from `GemVersion`. Ruby's `Gem::Version.new()` requires an argument and raises `ArgumentError` when called without one. A `Default` impl that silently produces an empty version doesn't match this behavior and could mask bugs at call sites.

## Test plan

- All existing tests pass (`cargo test`).
- No code in the crate uses `GemVersion::default()`.