### PR TITLE
Add GemVersionStrict for upstream-compatible display behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- Introduce `GemVersionStrict` that mirrors [the upstream coupling of display and version representation](https://github.com/ruby/rubygems/blob/dc7307cabf8768e39a08c68f86c149a683b327be/lib/rubygems/version.rb#L219-L222). Added diverging documentation for `GemVersion`.
 - Fix `license` field in Cargo.toml to `BSD-3-Clause` to match the LICENSE file (was incorrectly set to `MIT`)
 - Remove `Default` implementation from `GemVersion`. There is no meaningful default version string, and providing one via `Default` could silently hide bugs.
 - Fix `Display` implementation to preserve all version segments (e.g. `1.0.0` no longer drops trailing `.0` segments).

--- a/README.md
+++ b/README.md
@@ -27,3 +27,30 @@ use gem_version::GemVersion;
 let version = GemVersion::from_str("1.0.0").unwrap();
 assert!(version < GemVersion::from_str("2.0.0").unwrap());
 ```
+
+## Diverging behavior
+
+Ruby's Gem::Version reference implementation converts `-` to `.pre.` [commit introduced](https://github.com/ruby/rubygems/commit/df88d165d89cc7ece9b746589e58d93b76a33628). This means the value you put in is not the value you get out:
+
+```ruby
+puts Gem::Version.new("1.0.0-alpha1")
+# => "1.0.0.pre.alpha1"
+```
+
+It seems the coupling between comparison logic and representation was accidental at the time of introduction. This library diverges by showing the original string (and decoupling that from the comparison representation):
+
+```rust
+use std::str::FromStr;
+use gem_version::GemVersion;
+
+let version = GemVersion::from_str("1.0.0-alpha1").unwrap();
+
+assert_eq!("1.0.0-alpha1", &version.to_string());
+// But it performs comparisons as if they were the same.
+assert_eq!(
+    GemVersion::from_str("1.0.0.pre.alpha1").unwrap(),
+    version
+);
+```
+
+If you want the upstream (reference) behavior use [`GemVersionStrict`]. Construct via calling [`GemVersion::strict`].

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -172,6 +172,70 @@ fn drop_right_while<A, P: Fn(&A) -> bool>(i: Vec<A>, pred: P) -> Vec<A> {
     ret
 }
 
+impl GemVersion {
+    /// Returns a strict re-implementation of the reference Gem::Version
+    ///
+    /// See [`GemVersionStrict`] for documentation
+    pub fn strict(self) -> GemVersionStrict {
+        GemVersionStrict {
+            _inner: GemVersion {
+                version: self.version.replace("-", ".pre."),
+                segments: self.segments,
+            },
+        }
+    }
+}
+
+/// A strict re-implementation of the reference Gem::Version
+///
+/// - Replaces `-` with `.pre.` in the display [logic](https://github.com/ruby/rubygems/blob/dc7307cabf8768e39a08c68f86c149a683b327be/lib/rubygems/version.rb#L219-L222).
+///   this was introduced in [this commit](https://github.com/ruby/rubygems/commit/df88d165d89cc7ece9b746589e58d93b76a33628)
+///
+/// ```rust
+/// use std::str::FromStr;
+/// use gem_version::GemVersion;
+///
+/// let version = GemVersion::from_str("1.0.0-alpha1")
+///     .unwrap()
+///     .strict();
+///
+/// assert_eq!("1.0.0.pre.alpha1", &version.to_string());
+/// assert_eq!(
+///     GemVersion::from_str("1.0.0.pre.alpha1").unwrap(),
+///     version
+/// );
+/// ```
+///
+/// Construct via calling [`GemVersion::strict`].
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, PartialOrd)]
+pub struct GemVersionStrict {
+    _inner: GemVersion,
+}
+
+impl From<GemVersionStrict> for GemVersion {
+    fn from(value: GemVersionStrict) -> Self {
+        value._inner
+    }
+}
+
+impl fmt::Display for GemVersionStrict {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self._inner)
+    }
+}
+
+impl PartialEq<GemVersion> for GemVersionStrict {
+    fn eq(&self, other: &GemVersion) -> bool {
+        self._inner.eq(other)
+    }
+}
+
+impl PartialEq<GemVersionStrict> for GemVersion {
+    fn eq(&self, other: &GemVersionStrict) -> bool {
+        self.eq(&other._inner)
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;
@@ -298,6 +362,20 @@ mod test {
 
             // Preserves equality logic
             assert_eq!(v(&version.replace("-", ".pre.")), gem);
+        }
+    }
+
+    #[test]
+    fn test_strict_display_replacement() {
+        for version in &["1.0.0-alpha", "1.0.0-beta.2", "1.0.0-1"] {
+            let strict = v(version).strict();
+
+            // Changes display
+            assert_ne!(version, &&strict.to_string());
+            assert_eq!(version.replace("-", ".pre."), strict.to_string());
+
+            // Preserves equality logic
+            assert_eq!(v(version), strict);
         }
     }
 


### PR DESCRIPTION
## Summary

- Add `GemVersionStrict` type that mirrors Ruby's upstream `Gem::Version` coupling of display and comparison (replaces `-` with `.pre.` in `to_string()`).
- Add `GemVersion::strict()` method to convert.
- Add cross-type `PartialEq` impls between `GemVersion` and `GemVersionStrict`.
- Add "Diverging behavior" section to README documenting the difference.
- Add CHANGELOG entry for `GemVersionStrict`.

Stacked on #16.