### PR TITLE
Normalize semver dash to .pre. for comparison, preserve display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Fix `license` field in Cargo.toml to `BSD-3-Clause` to match the LICENSE file (was incorrectly set to `MIT`)
 - Remove `Default` implementation from `GemVersion`. There is no meaningful default version string, and providing one via `Default` could silently hide bugs.
 - Fix `Display` implementation to preserve all version segments (e.g. `1.0.0` no longer drops trailing `.0` segments).
+- Fix semver dash comparison: versions like `1.0.0-1` are now correctly treated as pre-releases (less than `1.0.0`). Display is not changed (e.g. `"1.0.0-alpha"` still displays as `"1.0.0-alpha"`, not `"1.0.0.pre.alpha"`).
 
 ## v0.3.1
 

--- a/README.md
+++ b/README.md
@@ -27,3 +27,32 @@ use gem_version::GemVersion;
 let version = GemVersion::from_str("1.0.0").unwrap();
 assert!(version < GemVersion::from_str("2.0.0").unwrap());
 ```
+
+## Diverging behavior
+
+Ruby's Gem::Version reference implementation converts `-` to `.pre.` [commit introduced](https://github.com/ruby/rubygems/commit/df88d165d89cc7ece9b746589e58d93b76a33628). This means the value you put in is not the value you get out:
+
+```ruby
+puts Gem::Version.new("1.0.0-alpha1")
+# => "1.0.0.pre.alpha1"
+```
+
+It seems the coupling between comparison logic and representation was accidental at the time of introduction. This library diverges by showing the original string (and decoupling that from the comparison representation):
+
+```rust
+use std::str::FromStr;
+use gem_version::GemVersion;
+
+let version = GemVersion::from_str("1.0.0-alpha1").unwrap();
+
+// Version does not have `.pre.` in it:
+assert_eq!("1.0.0-alpha1", &version.to_string());
+
+// But it performs comparisons as if it did:
+assert_eq!(
+    GemVersion::from_str("1.0.0.pre.alpha1").unwrap(),
+    version
+);
+```
+
+If you want the upstream (reference) behavior that also changes the display output, you can make a newtype that uses `replace("-", ".pre.")` on the input `String`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,9 +64,10 @@ impl FromStr for GemVersion {
             })
         } else if validation_regex().is_match(version_string).unwrap_or(false) {
             let version = version_string.trim().to_string();
+            let for_segments = version.replace("-", ".pre.");
 
             let (segments_l, segments_r) = segment_regex()
-                .find_iter(version_string)
+                .find_iter(&for_segments)
                 .map(|regex_match| {
                     regex_match.as_str().parse::<u32>().ok().map_or_else(
                         || VersionSegment::String(regex_match.as_str().to_string()),
@@ -270,6 +271,34 @@ mod test {
         assert_eq!("0", v("").to_string());
         assert_eq!("0", v("   ").to_string());
         assert_eq!("0", v(" ").to_string());
+    }
+
+    #[test]
+    // https://github.com/ruby/rubygems/blob/dc7307cabf8768e39a08c68f86c149a683b327be/test/rubygems/test_gem_version.rb#L194-L201
+    fn semver_comparison() {
+        assert!(v("1.0.0-alpha") < v("1.0.0-alpha.1"));
+        assert!(v("1.0.0-alpha.1") < v("1.0.0-beta.2"));
+        assert!(v("1.0.0-beta.2") < v("1.0.0-beta.11"));
+        assert!(v("1.0.0-beta.11") < v("1.0.0-rc.1"));
+        assert!(v("1.0.0-rc1") < v("1.0.0"));
+        assert!(v("1.0.0-1") < v("1"));
+    }
+
+    #[test]
+    // Diverges from upstream.
+    // Upstream replaces `-` with `.pre.` in the display introduced in https://github.com/ruby/rubygems/commit/df88d165d89cc7ece9b746589e58d93b76a33628
+    // and still on main https://github.com/ruby/rubygems/blob/dc7307cabf8768e39a08c68f86c149a683b327be/lib/rubygems/version.rb#L219-L222.
+    //
+    // This preserves the comparison behavior, but changes the display behavior
+    fn test_version_display() {
+        for version in &["1.0.0-alpha", "1.0.0-beta.2", "1.0.0-1"] {
+            let gem = v(version);
+            // Does NOT change display
+            assert_eq!(version, &&gem.to_string());
+
+            // Preserves equality logic
+            assert_eq!(v(&version.replace("-", ".pre.")), gem);
+        }
     }
 
     // Test helper method


### PR DESCRIPTION
## Summary

- Fix semver dash comparison: versions like `1.0.0-1` are now correctly treated as pre-releases (less than `1.0.0`). Internally converts `-` to `.pre.` for segment parsing only.
- Display is preserved: `"1.0.0-alpha"` still displays as `"1.0.0-alpha"`, not `"1.0.0.pre.alpha"`.
- Replaces the old `semver_display` test with `test_version_display` that verifies the diverging behavior.

Stacked on #8.