### PR TITLE
Implement Eq/Ord and add serde roundtrip test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Remove `Default` implementation from `GemVersion`. There is no meaningful default version string, and providing one via `Default` could silently hide bugs.
 - Fix `Display` implementation to preserve all version segments (e.g. `1.0.0` no longer drops trailing `.0` segments).
 - Fixed silently dropping uppercase letters from versions. Previously `1.0.0.Preview1` would be stored internally as `1.0.0.review1` due to a regex mistake. Uppercase characters are now correctly represented in versions.
+- Add `Eq` and `Ord` impls for `GemVersion`, enabling use in sorted collections and `.sort()`.
 
 ## v0.3.1
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -140,6 +140,7 @@ dependencies = [
  "fancy-regex",
  "regex",
  "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -153,6 +154,12 @@ name = "is_terminal_polyfill"
 version = "1.70.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8478577c03552c21db0e2724ffb8986a5ce7af88107e6be5d2ee6e158c12800"
+
+[[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "memchr"
@@ -235,6 +242,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.149"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
 ]
 
 [[package]]
@@ -338,3 +358,9 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,3 +20,4 @@ pedantic = { level = "warn", priority = -1 }
 
 [dev-dependencies]
 clap = {version = "4.5", features = ["derive"] }
+serde_json = "1.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,8 +107,10 @@ impl PartialEq<GemVersion> for GemVersion {
     }
 }
 
-impl PartialOrd<GemVersion> for GemVersion {
-    fn partial_cmp(&self, other: &GemVersion) -> Option<Ordering> {
+impl Eq for GemVersion {}
+
+impl Ord for GemVersion {
+    fn cmp(&self, other: &Self) -> Ordering {
         let max = cmp::max(self.segments.len(), other.segments.len());
 
         let default = VersionSegment::U32(0);
@@ -122,18 +124,24 @@ impl PartialOrd<GemVersion> for GemVersion {
             }
 
             return match (segment_l, segment_r) {
-                (VersionSegment::U32(_), VersionSegment::String(_)) => Some(Ordering::Greater),
-                (VersionSegment::U32(a), VersionSegment::U32(b)) => a.partial_cmp(b),
-                (VersionSegment::String(_), VersionSegment::U32(_)) => Some(Ordering::Less),
+                (VersionSegment::U32(_), VersionSegment::String(_)) => Ordering::Greater,
+                (VersionSegment::U32(a), VersionSegment::U32(b)) => a.cmp(b),
+                (VersionSegment::String(_), VersionSegment::U32(_)) => Ordering::Less,
                 (VersionSegment::String(a), VersionSegment::String(b)) => {
                     // We have yet to verify that the sorting rules for strings are the same between
                     // Rust's and Ruby's standard library. Tests seem to pass, but here be dragons!
-                    a.partial_cmp(b)
+                    a.cmp(b)
                 }
             };
         }
 
-        Some(Ordering::Equal)
+        Ordering::Equal
+    }
+}
+
+impl PartialOrd<GemVersion> for GemVersion {
+    fn partial_cmp(&self, other: &GemVersion) -> Option<Ordering> {
+        Some(self.cmp(other))
     }
 }
 
@@ -280,6 +288,13 @@ mod test {
         assert_ne!(v("1.0.0.preview2"), v("1.0.0.Preview2"));
         assert_ne!(v("1.0P"), v("1.0p"));
         assert!(v("1.0.0.Preview2") < v("1.0.0.preview2"));
+    }
+
+    #[test]
+    fn ord_enables_sorting() {
+        let mut versions = vec![v("3.0"), v("1.0"), v("2.0")];
+        versions.sort();
+        assert_eq!(versions, vec![v("1.0"), v("2.0"), v("3.0")]);
     }
 
     // Test helper method

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -291,6 +291,16 @@ mod test {
     }
 
     #[test]
+    fn serde_roundtrip() {
+        let original = v("3.1.2");
+        let serialized = serde_json::to_string(&original).unwrap();
+        assert_eq!(serialized, "\"3.1.2\"");
+
+        let deserialized: GemVersion = serde_json::from_str(&serialized).unwrap();
+        assert_eq!(original, deserialized);
+    }
+
+    #[test]
     fn ord_enables_sorting() {
         let mut versions = vec![v("3.0"), v("1.0"), v("2.0")];
         versions.sort();


### PR DESCRIPTION
## Summary

- Implement `Eq` and `Ord` for `GemVersion` — `PartialOrd` was already total, these were just missing.
- Add `serde_json` dev-dependency and serde roundtrip test (serde support has been untested since v0.3.0).