### PR TITLE
Fix segment regex to capture uppercase letters in version strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Fix `license` field in Cargo.toml to `BSD-3-Clause` to match the LICENSE file (was incorrectly set to `MIT`)
 - Remove `Default` implementation from `GemVersion`. There is no meaningful default version string, and providing one via `Default` could silently hide bugs.
 - Fix `Display` implementation to preserve all version segments (e.g. `1.0.0` no longer drops trailing `.0` segments).
+- Fixed silently dropping uppercase letters from versions. Previously `1.0.0.Preview1` would be stored internally as `1.0.0.review1` due to a regex mistake. Uppercase characters are now correctly represented in versions.
 
 ## v0.3.1
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,7 +35,7 @@ fn validation_regex() -> &'static fancy_regex::Regex {
 fn segment_regex() -> &'static regex::Regex {
     static SEGMENT_REGEX: OnceLock<regex::Regex> = OnceLock::new();
     SEGMENT_REGEX.get_or_init(|| {
-        regex::Regex::new("[0-9]+|[a-z]+").expect("Internal Error: Invalid Regular Expression!")
+        regex::Regex::new("[0-9]+|[a-zA-Z]+").expect("Internal Error: Invalid Regular Expression!")
     })
 }
 
@@ -277,6 +277,9 @@ mod test {
         // Regression: the segment regex `[0-9]+|[a-z]+` silently drops
         // uppercase letters (e.g., "Preview2" is parsed as "review2")
         assert_ne!(v("1.0.0.Preview2"), v("1.0.0.review2"));
+        assert_ne!(v("1.0.0.preview2"), v("1.0.0.Preview2"));
+        assert_ne!(v("1.0P"), v("1.0p"));
+        assert!(v("1.0.0.Preview2") < v("1.0.0.preview2"));
     }
 
     // Test helper method

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -272,6 +272,13 @@ mod test {
         assert_eq!("0", v(" ").to_string());
     }
 
+    #[test]
+    fn uppercase_letters_not_silently_dropped() {
+        // Regression: the segment regex `[0-9]+|[a-z]+` silently drops
+        // uppercase letters (e.g., "Preview2" is parsed as "review2")
+        assert_ne!(v("1.0.0.Preview2"), v("1.0.0.review2"));
+    }
+
     // Test helper method
     fn v(s: &str) -> GemVersion {
         s.parse().unwrap()


### PR DESCRIPTION
## Summary

The validation regex allows uppercase letters (`[0-9a-zA-Z]`) but the segment regex `[0-9]+|[a-z]+` only matched lowercase. This silently drops uppercase characters during parsing — e.g., `"Preview2"` is parsed as segments `["review", 2]` because the `P` doesn't match `[a-z]` and the regex starts matching at `r`.

Ruby's `Gem::Version` uses a case-insensitive regex `/\d+|[a-z]+/i` in [`partition_segments`](https://github.com/ruby/rubygems/blob/dc7307cabf8768e39a08c68f86c149a683b327be/lib/rubygems/version.rb#L447-L451) to capture both upper and lowercase while preserving the original case:

```ruby
def partition_segments(ver)
  ver.scan(/\d+|[a-z]+/i).map! do |s|
    /\A\d/.match?(s) ? s.to_i : -s
  end.freeze
end
```

Fix: change the Rust segment regex from `[0-9]+|[a-z]+` to `[0-9]+|[a-zA-Z]+`.