### PR TITLE
Enable clippy::pedantic linting

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,5 +15,8 @@ fancy-regex = "0.17"
 regex = "1.12"
 serde = { version = "1.0", features = ["derive"] }
 
+[lints.clippy]
+pedantic = { level = "warn", priority = -1 }
+
 [dev-dependencies]
 clap = {version = "4.5", features = ["derive"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -152,7 +152,7 @@ impl fmt::Display for VersionError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             VersionError::InvalidVersion(version) => {
-                write!(f, "Invalid version string: {}", version)
+                write!(f, "Invalid version string: {version}")
             }
         }
     }


### PR DESCRIPTION
## Summary

Enable Clippy's pedantic lint group to catch code quality issues and maintain higher code standards. This addresses the `uninlined_format_args` warning in the error display code.