### PR TITLE
Switch to cargo-rdme for README generation

### DIFF
--- a/.cargo-rdme.toml
+++ b/.cargo-rdme.toml
@@ -1,0 +1,4 @@
+# Defines the base heading level to use when inserting the crate's documentation in the
+# README.  If this is not set the crate's documentation will be inserted with its sections
+# belonging to the README section where the insertion happens.
+heading-base-level = 0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,10 @@ jobs:
         # Using RUSTDOCFLAGS until `cargo doc --check` is stabilised:
         # https://github.com/rust-lang/cargo/issues/10025
         run: RUSTDOCFLAGS="-D warnings" cargo doc --all-features --document-private-items --no-deps
+      - name: Install cargo-rdme
+        run: cargo install cargo-rdme --locked
+      - name: Check README is up to date
+        run: cargo rdme --check
 
   unit-test:
     runs-on: ubuntu-22.04

--- a/README.md
+++ b/README.md
@@ -1,18 +1,18 @@
-
 # Gem version
 
-## What
+<!-- cargo-rdme start -->
 
-Implement Ruby's [`Gem::Version`][Gem::Version] comparison logic in Rust:
+Implement Ruby's [`Gem::Version`](https://github.com/rubygems/rubygems/blob/ecc8e895b69063562b9bf749b353948e051e4171/lib/rubygems/version.rb)
+comparison logic in Rust.
 
-- [Gem::Version][Gem::Version]
-- [Gem::Version tests](https://github.com/rubygems/rubygems/blob/ecc8e895b69063562b9bf749b353948e051e4171/test/rubygems/test_gem_version.rb)
+See also: [Gem::Version tests](https://github.com/rubygems/rubygems/blob/ecc8e895b69063562b9bf749b353948e051e4171/test/rubygems/test_gem_version.rb)
 
-The main use case is for the Heroku Ruby buildpack <https://github.com/heroku/buildpacks-ruby> and associated ecosystem of managing Ruby logic inside of Rust.
+The main use case is for the Heroku Ruby buildpack <https://github.com/heroku/buildpacks-ruby>
+and associated ecosystem of managing Ruby logic inside of Rust.
 
 ## Install
 
-Add it to your cargo.toml:
+Add it to your Cargo.toml:
 
 ```shell
 $ cargo add gem_version
@@ -30,14 +30,19 @@ assert!(version < GemVersion::from_str("2.0.0").unwrap());
 
 ## Diverging behavior
 
-Ruby's [Gem::Version][Gem::Version] reference implementation converts `-` to `.pre.` [commit introduced](https://github.com/ruby/rubygems/commit/df88d165d89cc7ece9b746589e58d93b76a33628). This means the value you put in is not the value you get out:
+Ruby's [`Gem::Version`](https://github.com/rubygems/rubygems/blob/ecc8e895b69063562b9bf749b353948e051e4171/lib/rubygems/version.rb)
+reference implementation converts `-` to `.pre.`
+([commit](https://github.com/ruby/rubygems/commit/df88d165d89cc7ece9b746589e58d93b76a33628)).
+This means the value you put in is not the value you get out:
 
 ```ruby
 puts Gem::Version.new("1.0.0-alpha1")
 # => "1.0.0.pre.alpha1"
 ```
 
-It seems the coupling between comparison logic and representation was accidental at the time of introduction. This library diverges by showing the original string (and decoupling that from the comparison representation):
+It seems the coupling between comparison logic and representation was accidental
+at the time of introduction. This library diverges by showing the original string
+(and decoupling that from the comparison representation):
 
 ```rust
 use std::str::FromStr;
@@ -55,7 +60,7 @@ assert_eq!(
 );
 ```
 
-If you want the upstream (reference) behavior that also changes the display output, you can make a newtype that uses `replace("-", ".pre.")` on the input `String`.
+If you want the upstream (reference) behavior that also changes the display output,
+you can make a newtype that uses `replace("-", ".pre.")` on the input `String`.
 
-
-[Gem::Version]: https://github.com/rubygems/rubygems/blob/ecc8e895b69063562b9bf749b353948e051e4171/lib/rubygems/version.rb
+<!-- cargo-rdme end -->

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,63 @@
-#![doc = include_str!("../README.md")]
+//! Implement Ruby's [`Gem::Version`](https://github.com/rubygems/rubygems/blob/ecc8e895b69063562b9bf749b353948e051e4171/lib/rubygems/version.rb)
+//! comparison logic in Rust.
+//!
+//! See also: [Gem::Version tests](https://github.com/rubygems/rubygems/blob/ecc8e895b69063562b9bf749b353948e051e4171/test/rubygems/test_gem_version.rb)
+//!
+//! The main use case is for the Heroku Ruby buildpack <https://github.com/heroku/buildpacks-ruby>
+//! and associated ecosystem of managing Ruby logic inside of Rust.
+//!
+//! ## Install
+//!
+//! Add it to your Cargo.toml:
+//!
+//! ```shell
+//! $ cargo add gem_version
+//! ```
+//!
+//! ## Use
+//!
+//! ```
+//! use std::str::FromStr;
+//! use gem_version::GemVersion;
+//!
+//! let version = GemVersion::from_str("1.0.0").unwrap();
+//! assert!(version < GemVersion::from_str("2.0.0").unwrap());
+//! ```
+//!
+//! ## Diverging behavior
+//!
+//! Ruby's [`Gem::Version`](https://github.com/rubygems/rubygems/blob/ecc8e895b69063562b9bf749b353948e051e4171/lib/rubygems/version.rb)
+//! reference implementation converts `-` to `.pre.`
+//! ([commit](https://github.com/ruby/rubygems/commit/df88d165d89cc7ece9b746589e58d93b76a33628)).
+//! This means the value you put in is not the value you get out:
+//!
+//! ```ruby
+//! puts Gem::Version.new("1.0.0-alpha1")
+//! # => "1.0.0.pre.alpha1"
+//! ```
+//!
+//! It seems the coupling between comparison logic and representation was accidental
+//! at the time of introduction. This library diverges by showing the original string
+//! (and decoupling that from the comparison representation):
+//!
+//! ```
+//! use std::str::FromStr;
+//! use gem_version::GemVersion;
+//!
+//! let version = GemVersion::from_str("1.0.0-alpha1").unwrap();
+//!
+//! // Version does not have `.pre.` in it:
+//! assert_eq!("1.0.0-alpha1", &version.to_string());
+//!
+//! // But it performs comparisons as if it did:
+//! assert_eq!(
+//!     GemVersion::from_str("1.0.0.pre.alpha1").unwrap(),
+//!     version
+//! );
+//! ```
+//!
+//! If you want the upstream (reference) behavior that also changes the display output,
+//! you can make a newtype that uses `replace("-", ".pre.")` on the input `String`.
 
 use std::cmp;
 use std::cmp::Ordering;


### PR DESCRIPTION
## Summary

- The crate-level `//!` doc comment in `src/lib.rs` is now the source of truth for README content
- `cargo rdme` generates `README.md` from it, keeping docs.rs and GitHub in sync
- Code examples are now compiled doctests, verified by `cargo test`
- CI lint job checks that the README stays in sync via `cargo rdme --check`

https://crates.io/crates/cargo-rdme