### PR TITLE
Make serde an optional dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- Make `serde` an optional dependency behind a `serde` feature flag (breaking change)
 - Fix `license` field in Cargo.toml to `BSD-3-Clause` to match the LICENSE file (was incorrectly set to `MIT`)
 - Remove `Default` implementation from `GemVersion`. There is no meaningful default version string, and providing one via `Default` could silently hide bugs.
 - Fix `Display` implementation to preserve all version segments (e.g. `1.0.0` no longer drops trailing `.0` segments).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -138,6 +138,7 @@ version = "0.3.1"
 dependencies = [
  "clap",
  "fancy-regex",
+ "gem_version",
  "regex",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,11 @@ include = ["src/**/*", "LICENSE", "README.md"]
 [dependencies]
 fancy-regex = "0.17"
 regex = "1.12"
-serde = { version = "1.0", features = ["derive"] }
+serde = { version = "1.0", features = ["derive"], optional = true }
+
+[features]
+default = []
+serde = ["dep:serde"]
 
 [lints.clippy]
 pedantic = { level = "warn", priority = -1 }
@@ -21,3 +25,4 @@ pedantic = { level = "warn", priority = -1 }
 [dev-dependencies]
 clap = {version = "4.5", features = ["derive"] }
 serde_json = "1.0"
+gem_version = { path = ".", features = ["serde"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,11 +6,13 @@ use std::fmt;
 use std::str::FromStr;
 use std::sync::OnceLock;
 
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 /// See module docs for a usage example
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(try_from = "String", into = "String")]
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(try_from = "String", into = "String"))]
 pub struct GemVersion {
     version: String,
     segments: Vec<VersionSegment>,


### PR DESCRIPTION
## Summary

- Moves `serde` behind an optional `serde` feature flag
- Before: all users compiled `serde` + derive macros even if they never serialized
- After: opt in with `gem_version = { features = ["serde"] }`