### PR TITLE
Propagate regex errors instead of swallowing them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- Propagate regex errors as `VersionError::RegexError` instead of silently swallowing them
 - Fix `license` field in Cargo.toml to `BSD-3-Clause` to match the LICENSE file (was incorrectly set to `MIT`)
 - Remove `Default` implementation from `GemVersion`. There is no meaningful default version string, and providing one via `Default` could silently hide bugs.
 - Fix `Display` implementation to preserve all version segments (e.g. `1.0.0` no longer drops trailing `.0` segments).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,7 +62,10 @@ impl FromStr for GemVersion {
                 version: String::from("0"),
                 segments: vec![VersionSegment::U32(0)],
             })
-        } else if validation_regex().is_match(version_string).unwrap_or(false) {
+        } else if validation_regex()
+            .is_match(version_string)
+            .map_err(|e| VersionError::RegexError(e.to_string()))?
+        {
             let version = version_string.trim().to_string();
             let for_segments = version.replace('-', ".pre.");
 
@@ -149,6 +152,7 @@ impl PartialOrd<GemVersion> for GemVersion {
 #[derive(Debug, Eq, PartialEq)]
 pub enum VersionError {
     InvalidVersion(String),
+    RegexError(String),
 }
 
 impl std::error::Error for VersionError {
@@ -162,6 +166,9 @@ impl fmt::Display for VersionError {
         match self {
             VersionError::InvalidVersion(version) => {
                 write!(f, "Invalid version string: {version}")
+            }
+            VersionError::RegexError(msg) => {
+                write!(f, "Regex error during version validation: {msg}")
             }
         }
     }


### PR DESCRIPTION
## Summary

- `validation_regex().is_match().unwrap_or(false)` silently treated regex engine errors as "invalid version"
- Adds `VersionError::RegexError` variant so callers can distinguish invalid input from internal regex failures
- Regex errors now propagate via `map_err` instead of being silently swallowed