### PR TITLE
Replace fancy-regex with regex crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -61,21 +61,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bit-set"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
-dependencies = [
- "bit-vec",
-]
-
-[[package]]
-name = "bit-vec"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
-
-[[package]]
 name = "clap"
 version = "4.5.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -122,22 +107,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b6a852b24ab71dffc585bcb46eaf7959d175cb865a7152e35b348d1b2960422"
 
 [[package]]
-name = "fancy-regex"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72cf461f865c862bb7dc573f643dd6a2b6842f7c30b07882b56bd148cc2761b8"
-dependencies = [
- "bit-set",
- "regex-automata",
- "regex-syntax",
-]
-
-[[package]]
 name = "gem_version"
 version = "0.3.1"
 dependencies = [
  "clap",
- "fancy-regex",
  "regex",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,6 @@ readme = "README.md"
 include = ["src/**/*", "LICENSE", "README.md"]
 
 [dependencies]
-fancy-regex = "0.17"
 regex = "1.12"
 serde = { version = "1.0", features = ["derive"] }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,11 +22,11 @@ impl fmt::Display for GemVersion {
     }
 }
 
-fn validation_regex() -> &'static fancy_regex::Regex {
-    static VALIDATION_REGEX: OnceLock<fancy_regex::Regex> = OnceLock::new();
+fn validation_regex() -> &'static regex::Regex {
+    static VALIDATION_REGEX: OnceLock<regex::Regex> = OnceLock::new();
     VALIDATION_REGEX.get_or_init(|| {
-        fancy_regex::Regex::new(
-            "\\A\\s*([0-9]+(?>\\.[0-9a-zA-Z]+)*(-[0-9A-Za-z-]+(\\.[0-9A-Za-z-]+)*)?)?\\s*\\z",
+        regex::Regex::new(
+            "^\\s*([0-9]+(?:\\.[0-9a-zA-Z]+)*(-[0-9A-Za-z-]+(\\.[0-9A-Za-z-]+)*)?)?\\s*$",
         )
         .expect("Internal error: Bad Regex")
     })
@@ -62,7 +62,7 @@ impl FromStr for GemVersion {
                 version: String::from("0"),
                 segments: vec![VersionSegment::U32(0)],
             })
-        } else if validation_regex().is_match(version_string).unwrap_or(false) {
+        } else if validation_regex().is_match(version_string) {
             let version = version_string.trim().to_string();
             let for_segments = version.replace('-', ".pre.");
 


### PR DESCRIPTION
## Summary

- The `regex` crate is DFA-based (no catastrophic backtracking), making the atomic group `(?>...)` unnecessary
- `^`/`$` match string boundaries by default in the `regex` crate, replacing `\A`/`\z`
- Removes the `fancy-regex` dependency, reducing compile time and dependency count
- Also eliminates `unwrap_or(false)` since `regex::Regex::is_match` returns `bool` directly