### PR TITLE
Simplify drop_right_while implementation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -247,11 +247,11 @@ impl Ord for VersionSegment {
     }
 }
 
-fn drop_right_while<A, P: Fn(&A) -> bool>(i: Vec<A>, pred: P) -> Vec<A> {
-    // There is probably a more efficient way to do this.
-    let mut ret = i.into_iter().rev().skip_while(pred).collect::<Vec<A>>();
-    ret.reverse();
-    ret
+fn drop_right_while<A>(mut v: Vec<A>, pred: impl Fn(&A) -> bool) -> Vec<A> {
+    while v.last().is_some_and(&pred) {
+        v.pop();
+    }
+    v
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

- Before: reversed the vec, used `skip_while`, collected into a new vec, reversed again (2 allocations, 2 reversals)
- After: simple `pop()` loop that removes trailing matching elements in-place (0 extra allocations)